### PR TITLE
Set the bundler version based on tddium.yml.

### DIFF
--- a/config/tddium.yml
+++ b/config/tddium.yml
@@ -1,4 +1,5 @@
 :tddium:
+  :bundler_version: 1.3.5
   :test_pattern:
     - features/*.feature
     - spec/heroku_spec.rb

--- a/features/step_definitions/suite_steps.rb
+++ b/features/step_definitions/suite_steps.rb
@@ -56,6 +56,12 @@ Given /^the user can create a suite named "([^"]*)" on branch "([^"]*)"$/ do |na
   Antilles.install(:post, "/1/suites", {:status=>0, :suite=>make_suite_response(name, branch)}, :code=>201)
 end
 
+Given /^the user can create a suite named "([^"]*)" on branch "([^"]*)" with bundler "(.*?)"$/ do |name, branch, bundler|
+  resp = make_suite_response(name, branch)
+  resp["bundler"] = bundler
+  Antilles.install(:post, "/1/suites", {:status=>0, :suite=>resp}, :code=>201)
+end
+
 Given /^the user can create a ci\-disabled suite named "(.*?)" on branch "(.*?)"$/ do |name, branch|
   resp = make_suite_response(name, branch)
   options = {:code=>201}
@@ -95,6 +101,16 @@ Given /^the user is logged in, and can successfully create a new suite in a git 
     And the user is logged in
     And the user has no suites
     And the user can create a suite named "beta" on branch "test/foobar"
+  }
+end
+
+Given /^the user is logged in, and can successfully create a new suite in a git repo with bundler "([^"]*)"$/ do |bundler|
+  steps %Q{
+    Given the destination repo exists
+    And a git repo is initialized on branch "test/foobar"
+    And the user is logged in
+    And the user has no suites
+    And the user can create a suite named "beta" on branch "test/foobar" with "#{bundler}"
   }
 end
 

--- a/features/suite_command_tddium_yml.feature
+++ b/features/suite_command_tddium_yml.feature
@@ -24,6 +24,21 @@ Feature: suite command
     Then the output should contain "Created suite..."
     Then the exit status should be 0
 
+  Scenario: Configure new suite with bundler from tddium.yml
+    Given the user is logged in, and can successfully create a new suite in a git repo with bundler '1.3.5'
+    And a file named "config/tddium.yml" with:
+    """
+    ---
+    :tddium:
+      :bundler_version:  '1.3.5'
+    """
+    When I run `tddium suite --name=beta --ci-pull-url=disable --ci-push-url=disable --test-pattern=spec/*`
+    Then the output should contain "Looks like"
+    Then the output should contain "Detected branch test/foobar"
+    Then the output should contain "Configured bundler version 1.3.5 from config/tddium.yml"
+    Then the output should contain "Created suite..."
+    Then the exit status should be 0
+
   Scenario: Configure new suite with ruby from tddium.cfg
     Given the user is logged in, and can successfully create a new suite in a git repo
     And a file named "config/tddium.cfg" with:

--- a/lib/tddium/cli/prompt.rb
+++ b/lib/tddium/cli/prompt.rb
@@ -33,7 +33,7 @@ module Tddium
     def prompt_suite_params(options, params, current={})
       say Text::Process::DETECTED_BRANCH % params[:branch] if params[:branch]
       params[:ruby_version] ||= tool_version(:ruby)
-      params[:bundler_version] ||= tool_version(:bundle)
+      params[:bundler_version] ||= sniff_bundler_version
       params[:rubygems_version] ||= tool_version(:gem)
 
       ask_or_update = lambda do |key, text, default|

--- a/lib/tddium/cli/suite.rb
+++ b/lib/tddium/cli/suite.rb
@@ -102,6 +102,11 @@ module Tddium
         update_params[:ruby_version] = ruby_version
       end
 
+      bundler_version = sniff_bundler_version
+      if bundler_version && bundler_version != current_suite["bundler_version"] then
+        update_params[:bundler_version] = bundler_version
+      end
+
       test_configs = @repo_config[:tests] || []
       if test_configs != (current_suite['test_configs'] || []) then
         update_params[:test_configs] = test_configs
@@ -120,6 +125,9 @@ module Tddium
         end
         if update_params[:ruby_version]
           say Text::Process::UPDATED_RUBY_VERSION % ruby_version
+        end
+        if update_params[:bundler_version]
+          say Text::Process::UPDATED_BUNDLER_VERSION % bundler_version
         end
         if update_params[:test_configs]
           say Text::Process::UPDATED_TEST_CONFIGS % YAML.dump(test_configs)

--- a/lib/tddium/cli/util.rb
+++ b/lib/tddium/cli/util.rb
@@ -70,6 +70,17 @@ module Tddium
       return ruby_version
     end
 
+    def sniff_bundler_version
+      bundler = @repo_config[:bundler_version]
+      bundler = tool_version(:bundle)
+      if !bundler.nil? then
+        bundler.chomp!
+        bundler =~ /Bundler version (.*)\z/
+        bundler = $1
+      end
+      return bundler
+    end
+
     def ssh_key_fingerprint(pubkey)
       tmp = Tempfile.new('ssh-pub')
       tmp.write(pubkey)

--- a/lib/tddium/constant.rb
+++ b/lib/tddium/constant.rb
@@ -229,6 +229,7 @@ with Tddium.
       UPDATED_SUITE = "Updated suite successfully."
       UPDATED_TEST_PATTERN = "Updated test pattern to '%s'"
       UPDATED_RUBY_VERSION = "Updated ruby version to '%s'"
+      UPDATED_BUNDLER_VERSION = "Updated bundler version to '%s'"
       UPDATED_PYTHON_CONFIG = "Updated Python configuration:\n%s"
       UPDATED_TEST_CONFIGS = "Updated test configurations:\n%s"
       DEPENDENCY_VERSION = "... Detected %s %s"


### PR DESCRIPTION
Allow specifying bundler version in tddium.yml so auto-build on new branches works smoothly.
