### PR TITLE
Bug 393 better json output for status

### DIFF
--- a/lib/tddium/cli/commands/status.rb
+++ b/lib/tddium/cli/commands/status.rb
@@ -38,9 +38,9 @@ module Tddium
             Text::Status::NO_INACTIVE_SESSION, 
             Text::Status::INACTIVE_SESSIONS
           ) if suite_params
+          say Text::Process::RERUN_SESSION
         end
 
-        say Text::Process::RERUN_SESSION
       rescue TddiumClient::Error::Base => e
         exit_failure e.message
       end

--- a/spec/commands/status_spec.rb
+++ b/spec/commands/status_spec.rb
@@ -38,8 +38,8 @@ describe Tddium::TddiumCli do
       it "should display current status as valid JSON" do
         tddium_api.should_not_receive(:get_suites)
         tddium_api.should_receive(:get_sessions).exactly(2).times.and_return([])
-        STDOUT.should_receive(:puts).with(/running|history/i)
-        STDOUT.should_receive(:puts).with(/Re-run failures from a session with/i)
+        subject.should_receive(:puts).with(/running|history/i)
+        subject.should_not_receive(:puts).with(/Re-run failures from a session with/i)
         subject.stub(:options) { {:json => true } }
         subject.status
       end


### PR DESCRIPTION
Fixed bug #393 -  https://bugs.tddium.com/bugzilla/show_bug.cgi?id=393
Now JSON output for status has next structure:

```
{
  "running": {
    "git@github.com:solanolabs/tddium_site.git": [

    ]
  },
  "history": {
    "bug-241-add-start-stop-buttons-to-suite-item": [
      {
        "id": 464873,
        "repo_name": "tddium_site",
        "branch": "bug-241-add-start-stop-buttons-to-suite-item",
        "commit": "13a88d4918cdca696a01d660faa18fc9ccb37df6",
        "report": "https://api.tddium.com:443/reports/464873",
        "duration": 0,
        "status": "running",
        "start_time": "2013-10-29T19:34:38Z"
      },
      ...
    ]
  }
}
```

Didn't find new scenario for testing, old tests pass and cover fine.
