### PR TITLE
cleanup gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,3 @@
 source "http://rubygems.org"
 
-# Specify your gem's dependencies in tddium.gemspec
-gemspec
-
-group :development, :test do
-  gem 'aruba', '0.4.6'
-  gem 'rdiscount', '1.6.8'
-  gem 'pickle'
-  gem 'mimic'
-  gem 'daemons'
-  gem 'httparty', "0.9.0"
-  gem 'antilles'
-
-  gem 'rspec'
-  gem 'cucumber'
-end
+gemspec # Specify dependencies in tddium.gemspec

--- a/tddium.gemspec
+++ b/tddium.gemspec
@@ -2,22 +2,16 @@
 Copyright (c) 2011, 2012 Solano Labs All Rights Reserved
 =end
 
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "tddium/version"
+require "./lib/tddium/version"
 
 Gem::Specification.new do |s|
-  if RUBY_PLATFORM == 'java' then
-    s.name        = "tddium-jruby"
-  else
-    s.name        = "tddium"
-  end
+  s.name        = "tddium"
   s.version     = Tddium::VERSION
-  s.platform    = Gem::Platform::RUBY
+  s.platform    = (RUBY_PLATFORM == 'java' ? RUBY_PLATFORM : Gem::Platform::RUBY)
   s.authors     = ["Solano Labs"]
   s.email       = ["info@tddium.com"]
   s.homepage    = "https://github.com/solanolabs/tddium.git"
-  s.summary     = %q{tddium Hosted Test Environment}
+  s.summary     = "Run tests in tddium Hosted Test Environment"
   s.license     = "MIT"
   s.description = <<-EOF
 tddium runs your test suite simply and quickly in our managed
@@ -35,27 +29,30 @@ test::unit, and spinach.  Tddium also supports Javascript testing using
 jasmine, evergreen, and many other frameworks.
 EOF
 
-  s.rubyforge_project = "tddium"
-
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = `git ls-files lib bin`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
 
   s.add_runtime_dependency("thor")
   s.add_runtime_dependency("highline")
   s.add_runtime_dependency("json")
   s.add_runtime_dependency("launchy")
   s.add_runtime_dependency("tddium_client", "~> 0.4.2")
-  if RUBY_PLATFORM == 'java' then
+  if RUBY_PLATFORM == 'java'
     s.add_runtime_dependency('jruby-openssl')
     s.add_runtime_dependency("msgpack-jruby")
   else
     s.add_runtime_dependency("msgpack", "=0.5.6")
   end
 
-#  s.add_development_dependency("bundler", "~> 1.1.0")
+  s.add_development_dependency("aruba", "0.4.6")
+  s.add_development_dependency("rdiscount", "1.6.8")
+  s.add_development_dependency("pickle")
+  s.add_development_dependency("mimic")
+  s.add_development_dependency("daemons")
+  s.add_development_dependency("httparty", "0.9.0")
+  s.add_development_dependency("antilles")
   s.add_development_dependency("rspec")
+  s.add_development_dependency("cucumber")
   s.add_development_dependency("fakefs")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("rake")


### PR DESCRIPTION
The common practice is to release 1 gem per platform, so when you install it it pick the platform that fits.
also:
- remove dependencies from gemspec 
- remove rubyforge project since you do not have one
  - remove unnecessary files so gem is lighter/smaller
  - remove redundant require_path
  - simplify version require
