### PR TITLE
bisect

### DIFF
--- a/lib/tddium/cli/commands/bisect.rb
+++ b/lib/tddium/cli/commands/bisect.rb
@@ -1,0 +1,60 @@
+module Tddium
+  class TddiumCli < Thor
+    desc "bisect", "Bisect a failing test run"
+    desc "bisect files+ failing_file", "Find out which file causes pollution / makes the failing file fail"
+    def bisect(files)
+      failing = files.pop
+      if !files.include?(failing)
+        exit_failure "Files have to include the failing file, use the copy helper"
+      elsif files.size < 2
+        exit_failure "Files have to be more than 2, use the copy helper"
+      elsif !success?([failing])
+        exit_failure "#{failing} fails when run on it's own"
+      elsif success?(files)
+        exit_failure "tests pass locally"
+      else
+        loop do
+          a = remove_from(files, files.size / 2, :not => failing)
+          b = files - (a - [failing])
+          status, files = find_failing_set([a, b], failing)
+          if status == :finished
+            say "Fails when #{files.join(", ")} are run together"
+            break
+          elsif status == :continue
+            next
+          else
+            exit_failure "unable to isolate failure to 2 files"
+          end
+        end
+      end
+    end
+
+    private
+
+    def find_failing_set(sets, failing)
+      sets.each do |set|
+        next if set == [failing]
+        if !success?(set)
+          if set.size == 2
+            return [:finished, set]
+          else
+            return [:continue, set]
+          end
+        end
+      end
+      return [:failure, []]
+    end
+
+    def remove_from(set, x, options)
+      set.dup.delete_if { |f| f != options[:not] && (x -= 1) >= 0 }
+    end
+
+    def success?(files)
+      command = "bundle exec ruby #{files.map { |f| "-r./#{f.sub(/\.rb$/, "")}" }.join(" ")} -e ''"
+      say "Running: #{command}"
+      status = system(command)
+      say "Status: #{status ? "Success" : "Failure"}"
+      status
+    end
+  end
+end

--- a/spec/commands/bisect_spec.rb
+++ b/spec/commands/bisect_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'tddium/cli'
+require 'tddium/cli/commands/bisect'
+require 'tmpdir'
+
+describe Tddium::TddiumCli do
+  describe "#bisect" do
+    include_context "tddium_api_stubs"
+
+    def write(file, content)
+      File.open(file, "w") { |f| f.write(content) }
+    end
+
+    def run_valid_order
+      subject.bisect(["a.rb", "b.rb", "c.rb", "c.rb"])
+    end
+
+    around do |test|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir, &test)
+      end
+    end
+
+    before do
+      write "a.rb", "$a=1"
+      write "b.rb", "$b=1"
+      write "c.rb", "exit($b || 0)"
+      subject.stub(:say)
+    end
+
+    it "fails with missing failure" do
+      expect {
+        subject.bisect(["a.rb", "b.rb", "c.rb"])
+      }.to raise_error(SystemExit, /Files have to include the failing file/)
+    end
+
+    it "fails with to few files" do
+      expect {
+        subject.bisect(["a.rb", "a.rb"])
+      }.to raise_error(SystemExit, /Files have to be more than 2/)
+    end
+
+    it "fail quickly when there is no failure" do
+      write "c.rb", "exit(0)"
+      expect {
+        run_valid_order
+      }.to raise_error(SystemExit, /tests pass locally/)
+    end
+
+    it "fail quickly when file itself faiks" do
+      write "c.rb", "exit(1)"
+      expect do
+        run_valid_order
+      end.to raise_error(SystemExit, /c.rb fails when run on it's own/)
+    end
+
+    it "find the polluter" do
+      subject.should_receive(:say).with("Fails when b.rb, c.rb are run together")
+      run_valid_order
+    end
+
+    it "finds the polluter in a bigger set" do
+      10.times { |i| write "#{i}.rb", "$a#{i}=1" }
+      subject.should_receive(:say).with("Fails when b.rb, c.rb are run together")
+      subject.bisect(["a.rb", "0.rb", "1.rb", "2.rb", "b.rb", "3.rb", "4.rb", "5.rb", "6.rb", "7.rb", "c.rb", "8.rb", "9.rb", "c.rb"])
+    end
+  end
+end


### PR DESCRIPTION
basic idea is that whenever a test fails (and it's a ruby project for now...) you add a copy button that copies
`tddium bisect all.rb files.rb that.rb failed.rb that.rb` (files with failed + failed)
and then this guy figures out which combination causes the failure.
- keeps the ordering (a b c -> `a b ?` or `b c ?`)
- checks that the failing file fails on it's own
- checks that all files run together fail

@semipermeable 

output looks like this (c fails when b is run with it)

```
Running: bundle exec ruby -r./c -e ''
Status: Success
Running: bundle exec ruby -r./a -r./0 -r./1 -r./2 -r./b -r./3 -r./4 -r./5 -r./6 -r./7 -r./c -r./8 -r./9 -e ''
Status: Failure
Running: bundle exec ruby -r./4 -r./5 -r./6 -r./7 -r./c -r./8 -r./9 -e ''
Status: Success
Running: bundle exec ruby -r./a -r./0 -r./1 -r./2 -r./b -r./3 -r./c -e ''
Status: Failure
Running: bundle exec ruby -r./2 -r./b -r./3 -r./c -e ''
Status: Failure
Running: bundle exec ruby -r./3 -r./c -e ''
Status: Success
Running: bundle exec ruby -r./2 -r./b -r./c -e ''
Status: Failure
Running: bundle exec ruby -r./b -r./c -e ''
Status: Failure
Fails when b.rb, c.rb are run together
```

output is a bit verbose, but should help in debugging :)
