### PR TITLE
Bug 582 - added tag param to run command

### DIFF
--- a/lib/tddium/cli/commands/spec.rb
+++ b/lib/tddium/cli/commands/spec.rb
@@ -10,6 +10,7 @@ module Tddium
     desc "run [PATTERN]", "Run the test suite, or tests that match PATTERN"
     method_option :account, :type => :string, :default => nil,
       :aliases => %w(--org --organization)
+    method_option :tag, :type => :string, :default => nil
     method_option :user_data_file, :type => :string, :default => nil
     method_option :max_parallelism, :type => :numeric, :default => nil
     method_option :test_pattern, :type => :string, :default => nil
@@ -52,6 +53,7 @@ module Tddium
         say Text::Process::USING_SPEC_OPTION[:max_parallelism] % max_parallelism
       end
 
+      test_execution_params[:tag] = options[:tag] if options[:tag]
       test_pattern = nil
 
       if pattern.is_a?(Array) && pattern.size > 0 then


### PR DESCRIPTION
Fixed bug #582: https://bugs.tddium.com/bugzilla/show_bug.cgi?id=582

Now you can run tests from CLI with tag param: `tddium run --tag='Some tag for session'` - tag param will be added to session.
Another part of task, for showing tag in report header, located here: https://github.com/solanolabs/tddium_site/pull/505
