### PR TITLE
rerun last session from current branch when calling rerun without session id

### DIFF
--- a/lib/tddium/cli/commands/rerun.rb
+++ b/lib/tddium/cli/commands/rerun.rb
@@ -8,8 +8,10 @@ module Tddium
     method_option :max_parallelism, :type => :numeric, :default => nil
     method_option :no_op, :type=>:boolean, :default => false, :aliases => ["-n"]
     method_option :force, :type=>:boolean, :default => false
-    def rerun(session_id)
+    def rerun(session_id=nil)
       tddium_setup({:repo => false})
+
+      session_id ||= session_id_for_current_suite
 
       result = @tddium_api.query_session(session_id)
       tests = result['session']['tests']
@@ -24,6 +26,19 @@ module Tddium
 
       say cmd
       Kernel.exec(cmd) if !options[:no_op]
+    end
+
+    private
+
+    def session_id_for_current_suite
+      return unless suite_for_current_branch?
+      suite_params = {
+        :suite_id => @tddium_api.current_suite_id,
+        :active => false,
+        :limit => 1
+      }
+      session = @tddium_api.get_sessions(suite_params)
+      session[0]["id"]
     end
   end
 end

--- a/spec/commands/rerun_spec.rb
+++ b/spec/commands/rerun_spec.rb
@@ -17,5 +17,14 @@ describe Tddium::TddiumCli do
 
       subject.rerun(session_id)
     end
+
+    it "should produce a command line from an last session's results" do
+      tddium_api.should_receive(:current_suite_id).twice.and_return(123)
+      tddium_api.should_receive(:get_sessions).and_return([{"id" => 1234}])
+      tddium_api.should_receive(:query_session).with(1234).and_return(query_session_result)
+      Kernel.should_receive(:exec).with(/tddium run foo.rb/)
+
+      subject.rerun
+    end
   end
 end


### PR DESCRIPTION
I just want to call rerun and not have to do a status first to find the last session id for the current branch

@semipermeable
