### PR TITLE
highlight head so I instantly know it is running on latest

### DIFF
--- a/lib/tddium/cli/commands/status.rb
+++ b/lib/tddium/cli/commands/status.rb
@@ -69,6 +69,9 @@ module Tddium
       if current_sessions.empty? then
         say no_session_prompt
       else
+        commit_size = 0...7
+        head = @scm.current_commit[commit_size]
+
         say all_session_prompt % (params[:suite_id] ? status_branch : "")
         say ""
         table = [
@@ -79,14 +82,21 @@ module Tddium
           start_timeago = "%s ago" % Tddium::TimeFormat.seconds_to_human_time(Time.now - Time.parse(session["start_time"]))
 
           ["#{session["id"]}",
-            session["commit"] ? session['commit'][0...7] : '-      ',
+            session["commit"] ? session['commit'][commit_size] : '-      ',
             session["status"],
             duration,
             start_timeago]
         end
-        print_table table
+        say(capture_stdout { print_table table }.gsub(head, "\e[7m#{head}\e[0m"))
       end
     end
 
+    def capture_stdout
+      old, $stdout = $stdout, StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = old
+    end
   end
 end  


### PR DESCRIPTION
@semipermeable

my normal workflow after amending / adding is seeing if tddium is running the latest commit or something old (have to stop it and start a new build), this makes this easier since I then no longer have to look through my git log to see what my head is and compare.

before: no idea if it's running latest
![screen shot 2014-08-22 at 2 45 10 pm](https://cloud.githubusercontent.com/assets/11367/4017930/e244ce5a-2a45-11e4-9601-2d7610f4957e.png)

after: head build is highlighted
![screen shot 2014-08-22 at 2 44 43 pm](https://cloud.githubusercontent.com/assets/11367/4017928/e056535c-2a45-11e4-9ffd-d7d1b807c73d.png)

print_table does not support colors and built big columns (tried to patch it, but it's super complicated ...)
so I went with capture -> replace -> print
