### PR TITLE
bundle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tddium (1.22.0)
+    tddium (1.22.1)
       github_api
       highline
       json
@@ -48,15 +48,15 @@ GEM
     ffi (1.9.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    github_api (0.11.3)
+    github_api (0.12.1)
       addressable (~> 2.3)
-      descendants_tracker (~> 0.0.1)
+      descendants_tracker (~> 0.0.4)
       faraday (~> 0.8, < 0.10)
-      hashie (>= 1.2)
+      hashie (>= 3.2)
       multi_json (>= 1.7.5, < 2.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6.3)
       oauth2
-    hashie (3.1.0)
+    hashie (3.2.0)
     highline (1.6.21)
     httparty (0.9.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
gem was not bundled after latest patch, so just running bundle on clean checkout produces a diff
@semipermeable 
