### PR TITLE
run session fetches in parallel, they are slooow

### DIFF
--- a/lib/tddium/cli/commands/status.rb
+++ b/lib/tddium/cli/commands/status.rb
@@ -40,7 +40,11 @@ module Tddium
           } if suite_params
           puts JSON.pretty_generate(res)
         else
+          running_sessions = Thread.new { @tddium_api.get_sessions(repo_params) }
+          branch_sessions = Thread.new { @tddium_api.get_sessions(suite_params) }
+
           show_session_details(
+            running_sessions.value,
             status_branch,
             repo_params, 
             Text::Status::NO_ACTIVE_SESSION, 
@@ -48,6 +52,7 @@ module Tddium
             true
           )
           show_session_details(
+            branch_sessions.value,
             status_branch,
             suite_params, 
             Text::Status::NO_INACTIVE_SESSION, 
@@ -64,9 +69,7 @@ module Tddium
 
     private 
 
-    def show_session_details(status_branch, params, no_session_prompt, all_session_prompt, include_branch)
-      current_sessions = @tddium_api.get_sessions(params)
-
+    def show_session_details(current_sessions, status_branch, params, no_session_prompt, all_session_prompt, include_branch)
       say ""
       if current_sessions.empty? then
         say no_session_prompt

--- a/spec/commands/status_spec.rb
+++ b/spec/commands/status_spec.rb
@@ -82,11 +82,10 @@ describe Tddium::TddiumCli do
 
   describe "#show_session_details" do
     let(:branch) { false }
-    let(:output) { subject.send(:capture_stdout) { subject.send(:show_session_details, "xxx", {:suite_id => 1}, "X", "Y-%s-", branch) } }
+    let(:output) { subject.send(:capture_stdout) { subject.send(:show_session_details, [session], "xxx", {:suite_id => 1}, "X", "Y-%s-", branch) } }
 
     it "shows empty" do
-      expect(tddium_api).to receive(:get_sessions).once.and_return([])
-      output = subject.send(:capture_stdout) { subject.send(:show_session_details, "xxx", {}, "X", "Y", false) }
+      output = subject.send(:capture_stdout) { subject.send(:show_session_details, [], "xxx", {}, "X", "Y", false) }
       expect(output).to eq "\nX\n"
     end
 
@@ -103,7 +102,6 @@ describe Tddium::TddiumCli do
       before do
         now = Time.now
         expect(Time).to receive(:now).at_least(:once).and_return Time.at(now.to_i)
-        expect(tddium_api).to receive(:get_sessions).once.and_return([session])
       end
 
       it "shows normal" do


### PR DESCRIPTION
44s -> 22s ... not sure why these api calls are so slow, but this makes it a little less horrible ... especially since I mostly care for the current branch info ...

@semipermeable 
