### PR TITLE
861 bug ssh key removal

### DIFF
--- a/features/spec_command.feature
+++ b/features/spec_command.feature
@@ -17,6 +17,9 @@ Feature: spec command
   Scenario: Fail if user has uncommitted changes
     Given a git repo is initialized
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has a suite for "repo" on "master"
     And the user can create a session
     But the user has uncommitted changes to "foo.rb"
@@ -28,6 +31,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has a suite for "repo" on "master"
     And the user can create a session
     And the user successfully registers tests for the suite 
@@ -40,6 +46,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized on branch "foobar"
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has no suites
     And the user can create a suite named "work/foobar" on branch "foobar"
     And the user creates a suite for "work/foobar" on branch "foobar"
@@ -55,6 +64,9 @@ Feature: spec command
     Given the destination hg repo exists
     And an hg repo is initialized on branch "foobar"
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has no suites
     And the user can create an hg suite named "work/foobar" on branch "foobar"
     And the user creates a suite for "work/foobar" on branch "foobar"
@@ -71,6 +83,9 @@ Feature: spec command
     And a git repo is initialized on branch "foobar"
     And a .gitignore file exists in git
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has no suites
     And the user can create a suite named "work/foobar" on branch "foobar"
     And the user creates a suite for "work/foobar" on branch "foobar"
@@ -87,6 +102,9 @@ Feature: spec command
     And the SCM ready timeout is 0
     And a git repo is initialized on branch "foobar"
     And the user is logged in
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user has no suites
     And the user can create a suite named "work/foobar" on branch "foobar"
     And the user creates a pending suite for "work/foobar" on branch "foobar"
@@ -104,6 +122,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite with test_pattern: "spec/foo"
     And the tests start successfully
@@ -119,6 +140,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite with test_pattern: "spec/foo"
     And the tests start successfully
@@ -136,6 +160,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite
     And the tests start successfully
@@ -152,6 +179,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite
     And the tests start successfully
@@ -168,6 +198,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite
     And the tests start successfully
@@ -183,6 +216,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And the user can create a session
     And the user successfully registers tests for the suite
     And the tests start successfully
@@ -198,6 +234,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And a file named "config/<file name>" with:
     """
     ---
@@ -225,6 +264,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And a file named "config/<file name>" with:
     """
     ---
@@ -252,6 +294,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And a file named "config/<file name>" with:
     """
     ---
@@ -278,6 +323,9 @@ Feature: spec command
     Given the destination repo exists
     And a git repo is initialized
     And the user is logged in with a configured suite
+    And the user has the following keys:
+      | name      |
+      | default   |
     And a file named "config/<file name>" with:
     """
     ---

--- a/lib/tddium/cli/commands/keys.rb
+++ b/lib/tddium/cli/commands/keys.rb
@@ -29,13 +29,8 @@ module Tddium
       output_dir ||= Default::SSH_OUTPUT_DIR
 
       begin
-        keys_details = @tddium_api.get_keys
-        if keys_details.count{|x|x['name'] == name} > 0
-          exit_failure Text::Error::ADD_KEYS_DUPLICATE % name
-        end
-
+        keydata = Tddium::Ssh.validate_keys name, path, @tddium_api
         say Text::Process::ADD_KEYS_ADD % name
-        keydata = Tddium::Ssh.load_ssh_key(path, name)
         result = @tddium_api.set_keys({:keys => [keydata]})
 
         priv_path = path.sub(/[.]pub$/, '')
@@ -58,14 +53,9 @@ module Tddium
       output_dir ||= Default::SSH_OUTPUT_DIR
 
       begin
-        keys_details = @tddium_api.get_keys
-        if keys_details.count{|x|x['name'] == name} > 0
-          exit_failure Text::Error::ADD_KEYS_DUPLICATE % name
-        end
-
+        keydata = Tddium::Ssh.validate_keys name, output_dir, @tddium_api, true
         say Text::Process::ADD_KEYS_GENERATE % name
-        keydata = Tddium::Ssh.generate_keypair(name, output_dir)
-        
+
         result = @tddium_api.set_keys({:keys => [keydata]})
         outfile = File.expand_path(File.join(output_dir, "identity.tddium.#{name}"))
         say Text::Process::ADD_KEYS_GENERATE_DONE % [name, result["git_server"] || Default::GIT_SERVER, outfile]

--- a/lib/tddium/cli/commands/spec.rb
+++ b/lib/tddium/cli/commands/spec.rb
@@ -27,6 +27,7 @@ module Tddium
       suite_auto_configure unless options[:machine]
 
       exit_failure unless suite_for_current_branch?
+      exit_failure(Text::Error::NO_SSH_KEY) if @tddium_api.get_keys.empty?
 
       if @scm.changes?(options) then
         exit_failure(Text::Error::SCM_CHANGES_NOT_COMMITTED) if !options[:force]

--- a/lib/tddium/constant.rb
+++ b/lib/tddium/constant.rb
@@ -411,6 +411,7 @@ EOF
       LIST_KEYS_ERROR = "Error listing SSH keys"
       REMOVE_KEYS_ERROR = "Failed to remove key '%s'"
       ADD_KEYS_DUPLICATE = "You already have a key named '%s'"
+      ADD_KEY_CONTENT_DUPLICATE = "You already have a key named '%s' with the same content"
       ADD_KEYS_ERROR = "Failed to add key '%s'"
       LIST_CONFIG_ERROR = "Error listing configuration variables"
       ADD_CONFIG_ERROR = "Error setting configuration variable"
@@ -492,6 +493,10 @@ Usage: "tddium COMMAND [ARGS] [OPTIONS]". For available commands, run "tddium he
 EOF
       CONFIG_PATHS_COLLISION =<<EOF
 You have both solano.yml and tddium.yml in your repo. We don't support merging the configuration from both of these files, so you'll have to pick one. The tddium.yml file will soon be deprecated, so we recommend migrating all of your configuration to solano.yml.
+EOF
+      NO_SSH_KEY =<<EOF
+Aborting. You don't have any ssh key.
+Add an ssh key first, using `tddium keys:add` or visit web-site http://ci.solanolabs.com/user_settings/ssh_keys
 EOF
     end
   end

--- a/lib/tddium/ssh.rb
+++ b/lib/tddium/ssh.rb
@@ -38,6 +38,29 @@ module Tddium
          :hostname=>`hostname`, 
          :fingerprint=>`ssh-keygen -lf #{pub_filename}`}
       end
+
+      def validate_keys name, path, tddium_api, generate_new_key = false
+        keys_details, keydata = tddium_api.get_keys, nil
+
+        # key name should be unique
+        if keys_details.count{|x|x['name'] == name} > 0
+          abort Text::Error::ADD_KEYS_DUPLICATE % name
+        end
+
+        unless generate_new_key
+          # check out key's content uniqueness
+          keydata = self.load_ssh_key(path, name)
+          duplicate_keys = keys_details.select{|key| key['pub'] == keydata[:pub] }
+          unless duplicate_keys.empty?
+            abort Text::Error::ADD_KEY_CONTENT_DUPLICATE % duplicate_keys.first['name']
+          end
+        else
+          # generate new key
+          keydata = self.generate_keypair(name, path)
+        end
+
+        keydata
+      end
     end
   end
 end

--- a/spec/commands/keys_spec.rb
+++ b/spec/commands/keys_spec.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2014 Solano Labs All Rights Reserved
+
+require 'tddium/constant'
+require 'spec_helper'
+require 'tddium/cli'
+require 'tddium/cli/commands/keys'
+
+describe Tddium::TddiumCli do
+  include_context "tddium_api_stubs"
+
+  describe '.keys:add' do
+    it 'calls correct method' do
+      Tddium::Ssh.should_receive(:validate_keys).with('some_key', '/home/.ssh/id_rsa.pub', tddium_api)
+      tddium_api.should_receive(:set_keys).and_return({'gitserver' => 'api.tddium.com'})
+
+      subject.send('keys:add', 'some_key', '/home/.ssh/id_rsa.pub')
+    end
+  end
+
+  describe '.keys:gen' do
+    it 'calls corrent method' do
+      Tddium::Ssh.should_receive(:validate_keys).with(
+                                                      'some_key',
+                                                      Tddium::TddiumCli::Default::SSH_OUTPUT_DIR,
+                                                      tddium_api,
+                                                      true
+                                                      )
+      tddium_api.should_receive(:set_keys).and_return({'gitserver' => 'api.tddium.com'})
+
+      subject.send('keys:gen', 'some_key')
+    end
+  end
+end

--- a/spec/commands/spec_spec.rb
+++ b/spec/commands/spec_spec.rb
@@ -36,6 +36,7 @@ describe Tddium::TddiumCli do
       tddium_api.stub(:register_session)
       tddium_api.stub(:start_session).and_return(test_executions)
       tddium_api.stub(:poll_session).and_return(test_executions)
+      tddium_api.stub(:get_keys).and_return([{name: 'some_key', pub: 'some content'}])
     end
 
     it "should create a new session" do

--- a/spec/scm/scm_spec.rb
+++ b/spec/scm/scm_spec.rb
@@ -1,0 +1,40 @@
+# Copyright (c) 2014 Solano Labs All Rights Reserved
+
+require 'tddium/constant'
+require 'spec_helper'
+require 'tddium/cli'
+require 'tddium/ssh'
+
+describe Tddium::Ssh do
+  include_context "tddium_api_stubs"
+  include TddiumConstant
+
+  describe '.validate_keys' do
+    let(:key) do
+      { 'name' => 'some_key',
+        'pub' => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCZiP/MC0sT7pvXsh6ElZ9zlJwYqc2fOA/YFzMJFW89Ii3JZtaB0eOpT+fA2+BTxN5vlbDpgFi1A53rZ/iscdZWhIfMzRX/ehAQjs2jNgcj5k5kxjq3hRs3ULWAUqC+Ep1xh6I8Ev7e/wHuZSvXVR8ILWXhwzFTHd0VHQ4fnu7gyXD6Ka+DUSTJ7ydtbH7BS7voZeGdiJKPJkqe/cD7lzT3iznaXJGr1GwX4CQFgdOoJIwsrFx0CkiPDZ8eIxRTpfn80n+s3tM3HEERAnkJGVkymYVipfqmzBoL9zcwNZYg/S7GyBBwVRL+pZ2bpulydQ7FxXoU1cpPvHyX55c1Ufq7 wkj@tddium' }
+    end
+    let(:another_key) do
+      { name: 'title',
+        pub: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCZiP/MC0sT7pvXsh6ElZ9zlJwYqc2fOA/YFzMJFW89Ii3JZtaB0eOpT+fA2+BTxN5vlbDpgFi1A53rZ/iscdZWhIfMzRX/ehAQjs2jNgcj5k5kxjq3hRs3ULWAUqC+Ep1xh6I8Ev7e/wHuZSvXVR8ILWXhwzFTHd0VHQ4fnu7gyXD6Ka+DUSTJ7ydtbH7BS7voZeGdiJKPJkqe/cD7lzT3iznaXJGr1GwX4CQFgdOoJIwsrFx0CkiPDZ8eIxRTpfn80n+s3tM3HEERAnkJGVkymYVipfqmzBoL9zcwNZYg/S7GyBBwVRL+pZ2bpulydQ7FxXoU1cpPvHyX55c1Ufq7 wkj@tddium' }
+    end
+
+    it "aborts adding duplicate key's name" do
+      tddium_api.stub(:get_keys).and_return([key])
+      Tddium::Ssh.stub(:load_ssh_key).and_return(key)
+
+      expect{
+        subject.class.validate_keys(key['name'], 'some/path', tddium_api, false)
+      }.to raise_error(SystemExit, self.class::Text::Error::ADD_KEYS_DUPLICATE % key['name'])
+    end
+
+    it "aborts adding duplicate key's content" do
+      tddium_api.stub(:get_keys).and_return([key])
+      Tddium::Ssh.stub(:load_ssh_key).and_return(another_key)
+
+      expect{
+        subject.class.validate_keys(another_key['name'], 'some/path', tddium_api, false)
+      }.to raise_error(SystemExit, self.class::Text::Error::ADD_KEY_CONTENT_DUPLICATE % key['name'])
+    end
+  end
+end


### PR DESCRIPTION
Allow user to remove all ssh keys.
Prohibit user to add key with content, that already present in one of his keys.
Prohibit user to create session if he has no ssh key.

https://bugs.tddium.com/bugzilla/show_bug.cgi?id=861

Depends on https://github.com/solanolabs/tddium_site/pull/900
