### PR TITLE
CICLI-57

### DIFF
--- a/lib/tddium/cli/commands/spec.rb
+++ b/lib/tddium/cli/commands/spec.rb
@@ -291,8 +291,10 @@ module Tddium
 
     def read_and_encode_config_file
       fn = @repo_config.config_filename
-      if fn && File.exists?(fn) then
-        Base64.encode64(File.read(fn))
+      root = @scm.root
+
+      if fn && root && File.exists?(File.join(root, fn)) then
+        Base64.encode64(File.read(File.join(root, fn)))
       else
         nil
       end

--- a/spec/commands/spec_spec.rb
+++ b/spec/commands/spec_spec.rb
@@ -8,6 +8,18 @@ require 'tddium/cli/commands/spec'
 describe Tddium::TddiumCli do
   include_context "tddium_api_stubs"
 
+  describe "#read_and_encode_config_file" do
+    it "should return encoded config file" do
+      system("mkdir .tddiumtesting")
+      Dir.chdir ".tddiumtesting"
+
+      subject.send(:read_and_encode_config_file).should_not be_nil
+
+      Dir.chdir ".."
+      system("rm -rf .tddiumtesting")
+    end
+  end
+
   describe "#spec" do
     let(:commit_log_parser) { double(GitCommitLogParser) }
     let(:suite_id) { 1 }


### PR DESCRIPTION
read_and_encode_config_file was assuming tddium was being run from the root dir, where elsewhere in the code root wasn't being assumed. Prepending root path seems to have fixed the problem. 

Test written & passed: https://ci.solanolabs.com/reports/1147289
